### PR TITLE
Support for Trezor Model T & on-device passphrase entry

### DIFF
--- a/Etherwall.pro
+++ b/Etherwall.pro
@@ -19,12 +19,12 @@ win32 {
 macx {
     QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9
     INCLUDEPATH += /usr/local/include
-    INCLUDEPATH += /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/System/Library/Frameworks/IOKit.framework/Headers
-    INCLUDEPATH += /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/System/Library/Frameworks/CoreFoundation.framework/Headers
+    INCLUDEPATH += /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/IOKit.framework/Headers
+    INCLUDEPATH += /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/CoreFoundation.framework/Headers
     QMAKE_LFLAGS += -F/System/Library/Frameworks/CoreFoundation.framework -F/System/Library/Frameworks/IOKit.framework
     LIBS += -framework CoreFoundation
     LIBS += -framework IOKit
-    LIBS += /usr/local/lib/libhidapi.a /usr/local/lib/libprotobuf.a
+    LIBS += /usr/local/lib/libhidapi.a /usr/local/lib/libprotobuf.a /usr/local/lib/libusb-1.0.a
     ICON=qml/images/icon.icns
 }
 

--- a/src/trezor/trezor.cpp
+++ b/src/trezor/trezor.cpp
@@ -260,9 +260,7 @@ namespace Trezor {
             case MessageType_EthereumTxRequest: handleTxRequest(msg_in); return;
         }
 
-        if (false) {
-           bail("Unknown msg response: " + QString::number(msg_in.id));
-        }
+        bail("Unknown msg response: " + QString::number(msg_in.id));
     }
 
     void TrezorDevice::handleFailure(const Wire::Message &msg_in)

--- a/src/trezor/trezor.h
+++ b/src/trezor/trezor.h
@@ -106,6 +106,7 @@ namespace Trezor {
         void handleMatrixRequest(const Wire::Message& msg_in);
         void handleButtonRequest(const Wire::Message& msg_in);
         void handlePassphrase(const Wire::Message& msg_in);
+        void handlePassphraseStateRequest(const Wire::Message& msg_in);
         void handleFeatures(const Wire::Message& msg_in);
         void handleAddress(const Wire::Message& msg_in);
         void handleTxRequest(const Wire::Message& msg_in);

--- a/src/trezor/wire.cpp
+++ b/src/trezor/wire.cpp
@@ -234,7 +234,7 @@ namespace Wire {
     void Device::write(char_type const *data, size_t len)
     {
         if (!hid && !usb_dev) {
-            throw wire_error("Write called with null hid handle");
+            throw wire_error("Write called with null handle");
         }
 
         for (;;) {
@@ -297,7 +297,7 @@ namespace Wire {
     void Device::buffer_report()
     {
         if (!hid && !usb_dev) {
-            throw wire_error("Buffer report called with null hid handle");
+            throw wire_error("Buffer report called with null handle");
         }
 
         using namespace std;

--- a/src/trezor/wire.h
+++ b/src/trezor/wire.h
@@ -27,6 +27,7 @@
 #endif
 
 #include <hidapi/hidapi.h>
+#include <libusb-1.0/libusb.h>
 #include <QDebug>
 #include <QVariant>
 #include <QString>
@@ -73,6 +74,14 @@ namespace Wire {
         hid_device *hid;
         buffer_type read_buffer;
         int hid_version;
+        
+        libusb_context* usb;
+        libusb_device_handle* usb_dev;
+        int usb_max_size;
+        
+        enum {
+           Trezor_V1, Trezor_V2
+        } trezor_ver;
     };
 
     class Message


### PR DESCRIPTION
Following up on #99, I managed to get the Trezor Model T to work with Etherwall. I've tested importing the first 5 public keys, entering a passphrase on-device and via the app, as well as signing a transaction.

The following caveats apply:

- The code is a bit rough, I'm afraid.
- I don't have a Trezor One, so I couldn't test whether I broke anything with the HID-based protocol.
- I don't know how to detect a Trezor One running the newer USB based protocol, once it gets enabled there. Right now, all device detection works via VID/PID. I suppose one way to try would be to send a HID-based Initialize message and check for valid data, then switch to the USB-based protocol if that returns garbage data. I didn't implement this, though.
- When you are asked to enter a passphrase, the red-ish overlay calls the action you are doing on your trezor "undefined". I couldn't figure out how to address this... :-(
- I've kept the ability to do debug output of the transfer contents in wire.cpp in, disabled through an ifdef. I suppose this can be removed, though it might prove useful if problems are found with the new or old transfer protocol.
- I've also had to adapt the logic in trezor.cpp a bit – The Model T enables you to enter the passphrase on-device, which uses a (new) PassphraseStateRequest when entry is finished. I couldn't figure out exactly how this is supposed to work, but apparently, just sending back a PassphraseStateAck is enough to make it work, since the device (or host) can't figure out anyway if you entered the "correct" passphrase, e.g. the one you intended to use.
- I've built this on OS X 10.13, so I adapted Etherwall.pro to point to the 10.13 SDK – You will probably want to revert this back to 10.12 if that's what you're using for the builds.
- I've also added a static version of libusb-1.0 in Etherwall.pro as a build dependency. I'm using the version provided by Homebrew.